### PR TITLE
feat: Add right_shift + Japanese Kana (かな) to Japanese Eisuu (英数) map…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a custom `karabiner.json` configuration file for [Karab
 - `Right Command` → `Japanese Kana` (Disabled by default)
 - `Right Shift + Right Command` → `Japanese Eisuu` (Disabled by default)
 - `Japanese Eisuu (英数)` → `Enter`
+- `right_shift + Japanese Kana (かな)` → `Japanese Eisuu (英数)`
 - `Close Bracket ( ] )` → `Shift + 8` ( * )
 - `Backslash ( \ )` → `Shift + 9` ( ( )
 - `Spacebar` → `Right Shift` (acts as space when pressed alone)

--- a/docs/adr/0008-right_shift_kana_to_eisuu.md
+++ b/docs/adr/0008-right_shift_kana_to_eisuu.md
@@ -1,0 +1,17 @@
+# ADR 0008: right_shift + japanese_kanaでjapanese_eisuu、japanese_kana単独はそのまま
+
+## ステータス
+採用済み
+
+## コンテキスト
+- 日本語キーボードの「かな」キー（japanese_kana）は、通常そのまま使いたいが、右シフトと組み合わせて「英数」入力（japanese_eisuu）にも素早く切り替えたいニーズがあった。
+- 以前はsimple_modificationsで「かな」キーを別のキーにリマップしていたが、柔軟性に欠けていた。
+
+## 決定
+- simple_modificationsから「japanese_kana → keyboard_fn」のリマップを削除。
+- complex_modificationsで「right_shift + japanese_kana → japanese_eisuu」を追加。
+- 「japanese_kana」単独はデフォルト動作（かな入力切替）とする。
+
+## 結果
+- かなキー単独はそのまま「かな」入力切替。
+- 右シフト＋かなで「英数」入力切替が可能になり、入力効率が向上した。 

--- a/karabiner.json
+++ b/karabiner.json
@@ -355,6 +355,19 @@
                                 ]
                             }
                         ]
+                    },
+                    {
+                        "description": "right_shift + japanese_kana to japanese_eisuu",
+                        "manipulators": [
+                            {
+                                "type": "basic",
+                                "from": {
+                                    "key_code": "japanese_kana",
+                                    "modifiers": { "mandatory": ["right_shift"] }
+                                },
+                                "to": [ { "key_code": "japanese_eisuu" } ]
+                            }
+                        ]
                     }
                 ]
             },
@@ -372,10 +385,6 @@
                 {
                     "from": { "key_code": "japanese_eisuu" },
                     "to": [{ "key_code": "return_or_enter" }]
-                },
-                {
-                    "from": { "key_code": "japanese_kana" },
-                    "to": [{ "apple_vendor_top_case_key_code": "keyboard_fn" }]
                 },
                 {
                     "from": { "key_code": "return_or_enter" },


### PR DESCRIPTION
…ping; Removed simple_modifications remap for japanese_kana; Added complex_modifications rule: right_shift + japanese_kana → japanese_eisuu; Japanese Kana key alone now works as default (kana input); Updated README and added ADR 0008 for this change