### PR TITLE
docs: READMEを日本語に統一し、重複を解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,76 @@
 # Hkprofile
 
-## Overview
-This repository contains a custom `karabiner.json` configuration file for [Karabiner-Elements](https://karabiner-elements.pqrs.org/), a powerful keyboard customization tool for macOS. The configuration is designed to enhance typing efficiency and maintain home position ergonomics.
+## 概要
+このリポジトリは、macOS用の強力なキーボードカスタマイズツールである[Karabiner-Elements](https://karabiner-elements.pqrs.org/)の設定ファイル`karabiner.json`を含んでいます。この設定は、タイピング効率を向上させ、ホームポジションのエルゴノミクスを維持するように設計されています。
 
-## Features
+## 機能
 
-### Basic Key Remappings
+### 基本キーリマップ
 - `Caps Lock` → `Right Command`
-- `Spacebar` → `Right Shift` (acts as space when pressed alone)
-- `Japanese Eisuu (英数)` → `Enter`
-- `Enter` → Disabled
+- `Spacebar` → `Right Shift`（単独押しでスペース）
+- `英数` → `Enter`
+- `Enter` → 無効化
 - `Right Command` → `Delete/Backspace`
-- `Right Shift` → Disabled
+- `Right Shift` → 無効化
 
-### Japanese Input Mode Management
-- `Right Command` → `Japanese Kana` (Disabled by default)
-- `Right Shift + Right Command` → `Japanese Eisuu` (Disabled by default)
-- `right_shift + Japanese Kana (かな)` → `Japanese Eisuu (英数)`
-- Automatic EISUU (英数) mode when:
-  - Application is activated
-  - Left Command is released after app switching
+### 日本語入力モード管理
+- `Right Command` → `かな`（デフォルトで無効）
+- `Right Shift + Right Command` → `英数`（デフォルトで無効）
+- `Right Shift + かな` → `英数`
+- 以下のタイミングで自動的に英数モードに切り替わります：
+  - アプリケーションがアクティブになった時
+  - アプリケーション切り替え後にLeft Commandが離された時
 
-### Numeric Input (with Right Shift)
-- `Right Shift + B` → `1`
-- `Right Shift + N` → `2`
-- `Right Shift + M` → `3`
-- `Right Shift + H` → `4`
-- `Right Shift + J` → `5`
-- `Right Shift + K` → `6`
-- `Right Shift + U` → `7`
-- `Right Shift + I` → `8`
-- `Right Shift + O` → `9`
+### 数字キー（右シフトと組み合わせ）
+- `Right Shift + n` → `1`
+- `Right Shift + m` → `2`
+- `Right Shift + ,` → `3`
+- `Right Shift + j` → `4`
+- `Right Shift + k` → `5`
+- `Right Shift + l` → `6`
+- `Right Shift + i` → `7`
+- `Right Shift + o` → `8`
+- `Right Shift + p` → `9`
 - `Right Shift + 0` → `0`
-- `0` → `-` (replaces original hyphen key)
-  - *Note: Original number keys 1-9 and hyphen key are disabled to maintain home position ergonomics*
+- `0` → `-`（元のハイフンキーの代わり）
+  - *注: ホームポジションのエルゴノミクスを維持するため、元の数字キー1-9とハイフンキーは無効化されています*
 
-### Symbol Input (with Right Shift)
+### 記号入力（右シフトと組み合わせ）
 - `Right Shift + Q` → `!`
 - `Right Shift + P` → `=`
-  - *Note: Original Shift + 1 for ! and Shift + - for = are disabled to prevent accidental inputs*
+  - *注: 誤入力を防ぐため、元のShift + 1（!）とShift + -（=）は無効化されています*
 
-### Bracket and Special Character Remappings
-- `Close Bracket ( ] )` → `Shift + 8` ( * )
-- `Backslash ( \ )` → `Shift + 9` ( ( )
+### 括弧と特殊文字のリマップ
+- `]` → `Shift + 8`（*）
+- `\` → `Shift + 9`（(）
 - `Shift + Delete/Backspace` → `*`
-- `Shift + Enter` → `+` (Disabled by default)
-- `Shift + 8` → `[` (Open Bracket)
-- `Shift + 9` → `]` (Close Bracket)
+- `Shift + Enter` → `+`（デフォルトで無効）
+- `Shift + 8` → `[`
+- `Shift + 9` → `]`
 
-### Navigation
-- `Left Command + H/J/K/L` → Arrow keys (Left, Down, Up, Right)
-  - *Note: Uses Left Command for better home position ergonomics*
+### ナビゲーション
+- `Left Command + H/J/K/L` → 矢印キー（左/下/上/右）
+  - *注: ホームポジションのエルゴノミクスを考慮してLeft Commandを使用*
 
-### 数字キー
-
-数字キーは右シフトと組み合わせて使用します：
-
-- 右シフト + n → 1
-- 右シフト + m → 2
-- 右シフト + , → 3
-- 右シフト + j → 4
-- 右シフト + k → 5
-- 右シフト + l → 6
-- 右シフト + i → 7
-- 右シフト + o → 8
-- 右シフト + p → 9
-- 右シフト + 0 → 0
-
-0キーのみを押すと `-` が入力されます。
-
-## Installation
-1. Install [Karabiner-Elements](https://karabiner-elements.pqrs.org/)
-2. Clone this repository:
+## インストール方法
+1. [Karabiner-Elements](https://karabiner-elements.pqrs.org/)をインストール
+2. このリポジトリをクローン：
    ```sh
    git clone https://github.com/khidaka/Hkprofile.git
    ```
-3. Copy the `karabiner.json` file to your Karabiner configuration folder:
+3. `karabiner.json`ファイルをKarabinerの設定フォルダにコピー：
    ```sh
    cp karabiner.json ~/.config/karabiner/
    ```
-4. Open Karabiner-Elements and select the profile "Hk profile"
+4. Karabiner-Elementsを開き、"Hk profile"を選択
 
-## Customization
-You can modify `karabiner.json` to adjust key mappings according to your needs. Use the Karabiner-Elements "Complex Modifications" tab to enable or disable specific mappings.
+## カスタマイズ
+必要に応じて`karabiner.json`を編集して、キーマッピングを調整できます。Karabiner-Elementsの"Complex Modifications"タブを使用して、特定のマッピングを有効または無効にすることができます。
 
-## Development Environment
+## 開発環境
 - macOS
 - Karabiner-Elements
 
-## License
+## ライセンス
 MIT
 


### PR DESCRIPTION
- すべてのセクションを日本語に翻訳

- 重複していた数字キーの説明を統合

- より自然な日本語表現に修正

- 記号や括弧の説明を簡潔に

- 注釈を日本語に統一